### PR TITLE
Adding getZoom api mock for Map

### DIFF
--- a/src/createGoogleMapsMock.js
+++ b/src/createGoogleMapsMock.js
@@ -205,6 +205,9 @@ const createGoogleMapsMock = (libraries = []) => {
         'getBounds',
         'panToBounds',
       ]);
+      this.getDiv = jest.fn().mockImplementation(function () {
+        return this.mapDiv;
+      });
     }),
     MapTypeControlStyle: {
       DEFAULT: 0,

--- a/src/createGoogleMapsMock.js
+++ b/src/createGoogleMapsMock.js
@@ -199,6 +199,7 @@ const createGoogleMapsMock = (libraries = []) => {
         'setOptions',
         'setStreetView',
         'setTilt',
+        'getZoom',
         'setZoom',
         'fitBounds',
         'getBounds',


### PR DESCRIPTION
`getZoom` API mock was missing for the Map instance